### PR TITLE
Prevent crash in action-creator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o2web-react-core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "O2 Web React Core",
   "author": "o2web",
   "license": "MIT",

--- a/src/config/graphql/async-action-creator.js
+++ b/src/config/graphql/async-action-creator.js
@@ -26,7 +26,7 @@ export function asyncQuery(
     })
       .then((response) => {
         const payload = response.data;
-        const data = Object.values(payload)[0] || {};
+        const data = (payload.length > 0) ? Object.values(payload)[0] : {};
 
         const errors = data.errors || [];
         const responseType = response.errors || errors.length > 0 ? fail : success;
@@ -61,7 +61,7 @@ export function asyncMutation(
     })
       .then((response) => {
         const payload = response.data;
-        const data = Object.values(payload)[0] || {};
+        const data = (payload.length > 0) ? Object.values(payload)[0] : {};
 
         const errors = data.errors || [];
         const responseType = response.errors || errors.length > 0 ? fail : success;


### PR DESCRIPTION
Lorsque la requête d'API raise une erreur, le response.data est à null et ça cause une erreur js
```
TypeError: Cannot convert undefined or null to object
    at Function.values (<anonymous>)
    at index.es.js:6308
```